### PR TITLE
Add HA ingress support via nginx prefix-restorer

### DIFF
--- a/spoolman/Dockerfile
+++ b/spoolman/Dockerfile
@@ -1,9 +1,11 @@
-ARG BUILD_FROM
 FROM ghcr.io/donkie/spoolman:0.23.1
 
-# Expose port
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends curl nginx && rm -rf /var/lib/apt/lists/*
+
 EXPOSE 7912
 
+COPY nginx.conf.template /nginx.conf.template
 COPY run.sh /run.sh
 RUN chmod +x /run.sh
 

--- a/spoolman/config.yaml
+++ b/spoolman/config.yaml
@@ -27,5 +27,9 @@ options:
 schema:
   SPOOLMAN_DEBUG_MODE: bool
 homeassistant_api: false
-hassio_api: false
-privileged: []
+hassio_api: true
+# Ingress (web UI in HA sidebar)
+ingress: true
+ingress_port: 7912
+panel_icon: mdi:printer-3d-nozzle
+panel_title: Spoolman

--- a/spoolman/nginx.conf.template
+++ b/spoolman/nginx.conf.template
@@ -1,0 +1,28 @@
+worker_processes 1;
+error_log /dev/stdout info;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    access_log off;
+
+    server {
+        listen 7912;
+
+        location / {
+            rewrite ^(.*)$ __INGRESS_PATH__$1 break;
+            proxy_pass http://127.0.0.1:7913;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_read_timeout 300s;
+            proxy_buffering off;
+        }
+    }
+}

--- a/spoolman/run.sh
+++ b/spoolman/run.sh
@@ -10,26 +10,20 @@ SPOOLMAN_DIR_LOGS="$CONFIG_DIR/logs"
 SPOOLMAN_DIR_CACHE="$CONFIG_DIR/cache"
 OPTIONS_FILE="/data/options.json"
 
-# Read debug option from Home Assistant
 SPOOLMAN_DEBUG_MODE="false"
-
 if [ -f "$OPTIONS_FILE" ]; then
     SPOOLMAN_DEBUG_MODE=$(grep -Po '"SPOOLMAN_DEBUG_MODE"\s*:\s*\K(true|false)' "$OPTIONS_FILE" || echo "false")
 fi
-
 export SPOOLMAN_DEBUG_MODE
 echo "[INFO] Debug mode: ${SPOOLMAN_DEBUG_MODE}"
 
-# Making directories
 echo "[INFO] Ensuring data directories exist..."
 mkdir -p "$SPOOLMAN_DIR_DATA" "$SPOOLMAN_DIR_BACKUPS" "$SPOOLMAN_DIR_LOGS" "$SPOOLMAN_DIR_CACHE"
 
-# Permissions
 echo "[INFO] Setting correct permissions on add-on directories..."
 chown -R 1000:1000 "$CONFIG_DIR" || echo "[WARN] Could not change owner (possibly already correct)"
 chmod -R 755 "$CONFIG_DIR" || echo "[WARN] Could not change permissions (possibly already correct)"
 
-# --- Timezone diagnostic ---
 echo "[INFO] --- Timezone diagnostic ---"
 echo "[INFO] Host-provided TZ value: ${TZ:-<not set>}"
 if [ -n "${TZ}" ]; then
@@ -41,23 +35,43 @@ fi
 echo "[INFO] Effective timezone in container: ${TZ}"
 echo "[INFO] -------------------------------"
 
-# Export variables voor Spoolman
 export SPOOLMAN_DIR_DATA
 export SPOOLMAN_DIR_BACKUPS
 export SPOOLMAN_DIR_LOGS
 export SPOOLMAN_DIR_CACHE
 
-# Start Spoolman
-echo "[INFO] Launching Spoolman..."
+# Detect HA ingress path
+if [ -n "$SUPERVISOR_TOKEN" ]; then
+    echo "[INFO] Querying Supervisor API for ingress URL..."
+    INGRESS_URL=$(curl -s \
+        -H "Authorization: Bearer $SUPERVISOR_TOKEN" \
+        http://supervisor/addons/self/info \
+        | python3 -c "import sys, json; d = json.load(sys.stdin); print(d.get('data', {}).get('ingress_url', ''))" 2>/dev/null || echo "")
 
-# Check if an official entrypoint is present
+    if [ -n "$INGRESS_URL" ]; then
+        export SPOOLMAN_BASE_PATH="${INGRESS_URL%/}"
+        echo "[INFO] SPOOLMAN_BASE_PATH set to: ${SPOOLMAN_BASE_PATH}"
+
+        # Generate nginx config with the ingress path restored
+        sed "s|__INGRESS_PATH__|${SPOOLMAN_BASE_PATH}|g" /nginx.conf.template > /etc/nginx/nginx.conf
+        echo "[INFO] Starting nginx prefix-restorer on port 7912..."
+        nginx -c /etc/nginx/nginx.conf
+        echo "[INFO] nginx started."
+
+        # Spoolman runs on internal port 7913; nginx fronts it on 7912
+        export SPOOLMAN_PORT=7913
+    else
+        echo "[WARN] Could not determine ingress URL — running Spoolman directly on 7912"
+    fi
+fi
+
+echo "[INFO] Launching Spoolman..."
 if [ -x /entrypoint.sh ]; then
     exec /entrypoint.sh
 elif [ -x /docker-entrypoint.sh ]; then
     exec /docker-entrypoint.sh
 else
     echo "[INFO] Starting manually via Uvicorn..."
-    # Start Uvicorn with a single process and access logs disabled
     exec uvicorn spoolman.main:app \
         --host 0.0.0.0 \
         --port "${SPOOLMAN_PORT:-7912}" \


### PR DESCRIPTION
HA ingress strips the ingress prefix before forwarding requests to the container. Spoolman's SPOOLMAN_BASE_PATH mounts all routes under that prefix, so stripped requests returned 404.

Fix: nginx runs on port 7912 (ingress port) as a prefix-restorer. It queries the Supervisor API for the ingress URL at startup, then rewrites incoming requests to prepend that prefix before proxying to Spoolman on internal port 7913. Spoolman sees the full paths it expects.

Changes:
- Dockerfile: install nginx, copy nginx.conf.template, set USER root
- nginx.conf.template: new file, listens 7912, rewrites/proxies to 7913
- run.sh: detect ingress URL via Supervisor API, generate nginx config, start nginx in background, set SPOOLMAN_PORT=7913, exec entrypoint
- config.yaml: hassio_api: true, ingress: true, ingress_port: 7912